### PR TITLE
update readme for modern cmake syntax and incremental build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,12 @@ Additionally, you'll need the following libraries to build the Crash Reporter:
        cmake .. -G "Visual Studio 15 2017"
 
    Replace `"Visual Studio 15 2017"` with the desired [CMake generator name](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html), for example `"Visual Studio 15 2017 Win64"` for 64-bit builds.
+   Starting with CMake 3.1 the architecture should be specified seperately
+   
+       cmake .. -G "Visual Studio 16 2019" -A x64
+       
+   Valid Architectures are Win32, x64, ARM and ARM64. If you intend to use Visual Studios incremental builds, add -DDEVELOPER=1 to the command
+   
+       cmake .. -G "Visual Studio 16 2019" -A x64 -DDEVELOPER=1
 
 5. Build the generated solution in Visual Studio


### PR DESCRIPTION
together with lali i tried to set this up, and we noticed the cmake syntax has changed, so i documented this here

we also noticed that without -DDEVELOPER=1 one had to build the entire project every time. with it enabled one can just use the normal incremental build of visual studio. so i added info for that too